### PR TITLE
Fixed issue with PSD2PHP not working with inititated banking class. #9

### DIFF
--- a/src/PSD2PHP.php
+++ b/src/PSD2PHP.php
@@ -16,11 +16,17 @@
      */
 
      class PSD2PHP {
+         /**
+          * Bank instance
+          *
+          * @var mixed $bank
+          */
+          private $bank = null;
         /**
          * Main constructor for PSD2PHP.
          * 
-         * @var string $bank
-         * @var array $configuration
+         * @param string $bank
+         * @param array $configuration
          */
         public function __construct(string $bank, ...$configuration){
             // Capitalize first character of $bank
@@ -32,6 +38,41 @@
 
             $bank = __NAMESPACE__ . '\\Banks\\' . $bank . '\\' . $bank;
 
-            return new $bank(...$configuration);
+            $this->bank = new $bank(...$configuration);
+        }
+
+        /**
+         * Call method
+         * 
+         * @param string $function
+         * @param array $parameters
+         * 
+         * @return mixed
+         */
+        public function __call(string $function, array $parameters){
+            $this->bank->{$function}(...$parameters);
+        }
+
+        /**
+         * Get variable
+         * 
+         * @param string $variable
+         * 
+         * @return mixed
+         */
+        public function __get(string $variable){
+            return $this->bank->{$variable};
+        }
+
+        /**
+         * Set variable
+         * 
+         * @param string $variable
+         * @param mixed $value
+         * 
+         * @return void
+         */
+        public function __set(string $variable, $value){
+            $this->bank->{$variable} = $value;
         }
      }


### PR DESCRIPTION
I've changed the logic of the PSD2PHP class to not return the banking class due to an error causing the banking methods to not be accessible. I've changed it to set the a `private $bank` variable that will be used by the `__call`, `__get` and `__set` methods.